### PR TITLE
feat: update global theme to black/blue with purple accents

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,6 +21,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.12);
 }
 
+
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
   --ifm-color-primary: #60a5fa;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,39 +6,41 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #0288D1;
-  --ifm-color-primary-dark: #0277BD;
-  --ifm-color-primary-darker: #026aa7;
-  --ifm-color-primary-darkest: #01579B;
-  --ifm-color-primary-light: #03A9F4;
-  --ifm-color-primary-lighter: #4FC3F7;
-  --ifm-color-primary-lightest: #B3E5FC;
+  --ifm-color-primary: #2563eb;
+  --ifm-color-primary-dark: #1d4ed8;
+  --ifm-color-primary-darker: #1e40af;
+  --ifm-color-primary-darkest: #1e3a8a;
+  --ifm-color-primary-light: #3b82f6;
+  --ifm-color-primary-lighter: #6366f1;
+  --ifm-color-primary-lightest: #a78bfa;
+  --ifm-background-color: #0b1020;
+  --ifm-navbar-background-color: #0b1020;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 136, 209, 0.1);
+  --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.12);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #0288D1;
-  --ifm-color-primary-dark: #03A9F4;
-  --ifm-color-primary-darker: #0288D1;
-  --ifm-color-primary-darkest: #01579B;
-  --ifm-color-primary-light: #81D4FA;
-  --ifm-color-primary-lighter: #B3E5FC;
-  --ifm-color-primary-lightest: #E1F5FE;
-  --ifm-background-color: #1b1b1d;
-  --ifm-navbar-background-color: #1b1b1d;
-  --docusaurus-highlighted-code-line-bg: rgba(76, 195, 247, 0.15);
+  --ifm-color-primary: #60a5fa;
+  --ifm-color-primary-dark: #3b82f6;
+  --ifm-color-primary-darker: #2563eb;
+  --ifm-color-primary-darkest: #1d4ed8;
+  --ifm-color-primary-light: #818cf8;
+  --ifm-color-primary-lighter: #a78bfa;
+  --ifm-color-primary-lightest: #c4b5fd;
+  --ifm-background-color: #05070f;
+  --ifm-navbar-background-color: #05070f;
+  --docusaurus-highlighted-code-line-bg: rgba(129, 140, 248, 0.2);
 }
 
 /* Button */
 :root {
-  --custom-button-bg: #ffffff; /* dark blue for light mode */
-  --custom-button-text: #000000;
+  --custom-button-bg: #1d4ed8;
+  --custom-button-text: #f8fafc;
 }
 
 [data-theme='dark'] {
-  --custom-button-bg: #1b1b1d; /* lighter blue for dark mode */
+  --custom-button-bg: #312e81;
   --custom-button-text: #ffffff;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,8 @@
   --ifm-color-primary-lightest: #a78bfa;
   --ifm-background-color: #0b1020;
   --ifm-navbar-background-color: #0b1020;
+  --ifm-font-color-base: #e5e7eb;
+  --ifm-heading-color: #f9fafb;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.12);
 }


### PR DESCRIPTION
## Summary
- updates the global site theme to a black/blue foundation with purple accents
- keeps the existing layout and component structure unchanged
- applies changes through global theme variables for consistent styling across pages

## What changed
- updated Docusaurus color tokens in the global stylesheet
- adjusted primary color shades for both light and dark modes
- tuned button and code-line highlight colors to match the new palette

## Why
- aligns the visual identity to a darker black/blue look while adding purple for contrast and accents
- keeps the change scoped to theming only, with no content or navigation changes

## Validation
- manually verified in local dev (`npm run start`) for visual consistency across key pages
- no functional behavior changes expected