### PR TITLE
Fix light mode theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -13,12 +13,12 @@
   --ifm-color-primary-light: #3b82f6;
   --ifm-color-primary-lighter: #6366f1;
   --ifm-color-primary-lightest: #a78bfa;
-  --ifm-background-color: #0b1020;
-  --ifm-navbar-background-color: #0b1020;
-  --ifm-font-color-base: #e5e7eb;
-  --ifm-heading-color: #f9fafb;
+  --ifm-background-color: #ffffff;
+  --ifm-navbar-background-color: #ffffff;
+  --ifm-font-color-base: #1f2937;
+  --ifm-heading-color: #111827;
   --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(99, 102, 241, 0.12);
+  --docusaurus-highlighted-code-line-bg: rgba(37, 99, 235, 0.1);
 }
 
 
@@ -61,13 +61,13 @@
 
 /** Desktop **/
 :root {
-  --hero-title-color: #ffffff;
-  --hero-subtitle-color: #ffffff;
+  --hero-title-color: #111827;
+  --hero-subtitle-color: #374151;
 }
 
 [data-theme='dark'] {
   --hero-title-color: #ffffff;
-  --hero-subtitle-color: #ffffff;
+  --hero-subtitle-color: #e5e7eb;
 }
 /* Title */
 .hero__title {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -31,8 +31,10 @@
   --ifm-color-primary-light: #818cf8;
   --ifm-color-primary-lighter: #a78bfa;
   --ifm-color-primary-lightest: #c4b5fd;
-  --ifm-background-color: #05070f;
-  --ifm-navbar-background-color: #05070f;
+  --ifm-background-color: #0f172a;
+  --ifm-navbar-background-color: #0f172a;
+  --ifm-font-color-base: #e2e8f0;
+  --ifm-heading-color: #f8fafc;
   --docusaurus-highlighted-code-line-bg: rgba(129, 140, 248, 0.2);
 }
 


### PR DESCRIPTION
## Summary
Fixes theme readability issues in both light and dark modes.

## Changes
- **Light mode:** Changed from dark background (`#0b1020`) to white (`#ffffff`) with dark text (`#1f2937`, `#111827`)
- **Dark mode:** Added missing text color variables (`#e2e8f0`, `#f8fafc`) and adjusted background to `#0f172a` for better contrast
- **Hero section:** Updated title/subtitle colors to match each theme

## Before
- Light mode had dark background with light text (unreadable)
- Dark mode was missing explicit text color definitions

## After
- Both modes have proper contrast and readable text