### PR TITLE
Fix Bitwarden social card path - change .svg to .png

### DIFF
--- a/docs/password-managers/bitwarden/getting-started-with-bitwarden.mdx
+++ b/docs/password-managers/bitwarden/getting-started-with-bitwarden.mdx
@@ -2,7 +2,7 @@
 title: Getting Started with Bitwarden
 description: A beginner-friendly introduction to Bitwarden and why it's a great choice for managing your passwords. Learn setup, features, and best practices.
 keywords: [bitwarden setup, bitwarden guide, bitwarden tutorial, how to use bitwarden, bitwarden features, password manager setup]
-image: /img/social-cards/bitwarden-social-card.svg
+image: /img/social-cards/bitwarden-social-card.png
 ---
 
 # Getting Started with Bitwarden


### PR DESCRIPTION
## Summary
Fixes broken social card image for the Bitwarden getting started page.

## Issue
The frontmatter in `getting-started-with-bitwarden.mdx` referenced `.svg` but the actual file is `.png`.

## Fix
Changed `image: /img/social-cards/bitwarden-social-card.svg` to `image: /img/social-cards/bitwarden-social-card.png`