### PR TITLE
Fix homepage social card path and update description

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -103,7 +103,7 @@ const config: Config = {
       { name: 'twitter:card', content: 'summary_large_image' },
     ],
     // Replace with your project's social card
-    image: 'blue-shield-social-card.jpg',
+    image: 'img/blue-shield-social-card.jpg',
     colorMode: {
       defaultMode: 'dark',
       disableSwitch: false,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title={`NetworkWilbiDocs`}
-      description="Description will go into a meta tag in <head />">
+      description="A community-driven hub for cybersecurity, privacy, and finding the balance between security and convenience.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
## Summary
Fixes the social card image not appearing when sharing https://docs.networkwilbi.com

## Changes
- **docusaurus.config.ts**: Fixed image path from `blue-shield-social-card.jpg` to `img/blue-shield-social-card.jpg`
- **index.tsx**: Updated placeholder description to meaningful text for social sharing

## Issue
The `themeConfig.image` path was missing the `img/` folder prefix, causing the OG image meta tag to point to a non-existent file.