### PR TITLE
Restructure blog: add date prefixes and authors.yml

### DIFF
--- a/blog/2026-03-08-welcome-to-WilbiDocs/index.mdx
+++ b/blog/2026-03-08-welcome-to-WilbiDocs/index.mdx
@@ -2,6 +2,7 @@
 slug: welcome-to-networkwilbi-blog
 title: Welcome to the NetworkWilbi Blog
 tags: [networkwilbi, security, docs]
+authors: [Wilbi]
 ---
 
 Welcome to the new NetworkWilbi blog.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,0 +1,8 @@
+Wilbi:
+  name: Wilbi
+  title: Homelab Enthusiast & Self-Hosting Advocate
+  url: https://github.com/networkwilbi
+  image_url: https://avatars.githubusercontent.com/u/159230586?v=4
+  socials:
+    github: networkwilbi
+    discord: https://discord.gg/ezsZEU2FZ9

--- a/blog/optery/2026-03-08-moving-family-to-optery.mdx
+++ b/blog/optery/2026-03-08-moving-family-to-optery.mdx
@@ -2,11 +2,14 @@
 slug: moving-family-to-optery-blog
 title: Moving Family to Optery
 tags: [optery, data-brokers, data-removal, family, personal, privacy]
+authors: [Wilbi]
 ---
 
 I have a problem.
 
 My family members have an astonishing amount of personal information about them publicly accessible online. With just a few searches, you can find phone numbers, addresses, email addresses, and other personal details tied directly to them. None of this information was intentionally shared by them, yet it exists across countless websites and databases where virtually anyone can access it. Seeing how easily this information could be found made me curious about how it got there in the first place.
+
+<!--truncate-->
 
 Instead of ignoring it, I started digging deeper by searching through data broker sites, people-search engines, and other public databases. As I examined the patterns, one thing became clear. The only way this much information could exist across so many platforms is if their Personally Identifiable Information (PII) had been widely exposed, aggregated, and redistributed online.
 


### PR DESCRIPTION
## Restructure Blog for Docusaurus Best Practices

### Summary
Reorganizes the blog structure to follow Docusaurus conventions with date-prefixed folders and adds author configuration.

### Changes
- **Blog post organization**: Moved blog posts into date-prefixed directories (`2026-03-08-welcome-to-WilbiDocs/`, `2026-03-08-moving-family-to-optery.mdx`) for proper sorting and URL generation
- **Authors configuration**: Added authors.yml with author profile (name, title, avatar, social links)
- **Frontmatter updates**: Updated posts to reference the new author configuration

### Why
- Enables consistent date-based URL slugs
- Centralizes author information for reuse across posts
- Follows Docusaurus blog best practices for maintainability